### PR TITLE
Add OpenAI chat completions endpoint for credit card rewards information

### DIFF
--- a/server/app/transactions/plaid.py
+++ b/server/app/transactions/plaid.py
@@ -1281,6 +1281,25 @@ def get_optimal_cashback(user_id=None):
 def chat_completions():
     """
     Endpoint to create a chat completion with OpenAI
+    Returns in this format:
+    {
+        "card_type": "chase sapphire preffered",
+        "extra_info": {
+            "annual_fee": "$95",
+            "card_name": "Chase Sapphire Preferred",
+            "notes": "Points are worth 25% more when redeemed for travel through Chase Ultimate Rewards.",
+            "signup_bonus": "Earn 60,000 bonus points after you spend $4,000 on purchases in the first 3 months from account opening."
+        },
+        "raw_content": "```python\n{\n    'card_name': 'Chase Sapphire Preferred',\n    'reward_categories': [\n        '5x points on travel purchased through Chase Ultimate Rewards',\n        '3x points on dining',\n        '3x points on online grocery purchases (excluding Target, Walmart, and wholesale clubs)',\n        '3x points on select streaming services',\n        '2x points on all other travel purchases',\n        '1x point on all other purchases'\n    ],\n    'signup_bonus': 'Earn 60,000 bonus points after you spend $4,000 on purchases in the first 3 months from account opening.',\n    'annual_fee': '$95',\n    'notes': 'Points are worth 25% more when redeemed for travel through Chase Ultimate Rewards.'\n}\n```",
+        "reward_categories": [
+            "5x points on travel purchased through Chase Ultimate Rewards",
+            "3x points on dining",
+            "3x points on online grocery purchases (excluding Target, Walmart, and wholesale clubs)",
+            "3x points on select streaming services",
+            "2x points on all other travel purchases",
+            "1x point on all other purchases"
+        ]
+    }
     """
 
     OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')


### PR DESCRIPTION
### TL;DR

Added a new endpoint to query OpenAI for credit card rewards information.

### What changed?

- Added a new `/chat/completions` endpoint to the Plaid blueprint
- Implemented functionality to query OpenAI's API for information about credit card rewards and signup bonuses
- The endpoint accepts a `card_type` parameter and returns detailed information about that specific credit card
- Added proper error handling and logging throughout the process

### How to test?

1. Ensure the `OPENAI_API_KEY` environment variable is set
2. Send a POST request to `/chat/completions` with JSON payload:
   ```json
   {
     "card_type": "Chase Sapphire Preferred"
   }
   ```
3. Verify the response contains information about the specified card's rewards and signup bonuses
4. Test error cases by omitting required fields or using an invalid API key

### Why make this change?

This endpoint allows users to get up-to-date information about credit card rewards programs directly through our API. By leveraging OpenAI's knowledge base, we can provide accurate details about various credit cards without maintaining our own database of constantly changing reward structures and signup bonuses.