### PR TITLE
BE deployment: add CORS

### DIFF
--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -18,7 +18,7 @@ def create_app():
     
     # Initialize CORS with specific configuration
     CORS(app, 
-         resources={r"/*": {"origins": ["http://localhost:3000", "http://127.0.0.1:3000", "https://www.smartswipe.co"]}},
+         resources={r"/*": {"origins": ["http://localhost:3000", "http://127.0.0.1:3000", "https://www.smartswipe.co", "http://smartswipe.co", "https://smartswipe.co"]}},
          supports_credentials=True,
          allow_headers=["Content-Type", "Authorization"],
          methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"])


### PR DESCRIPTION
### TL;DR

Added additional domain variations to the CORS allowed origins list.

### What changed?

Added `http://smartswipe.co` and `https://smartswipe.co` to the CORS configuration's allowed origins list in the Flask application. Previously, only `https://www.smartswipe.co` was included alongside the localhost development URLs.

### How to test?

1. Deploy the updated server code
2. Access the API from both `http://smartswipe.co` and `https://smartswipe.co` domains
3. Verify that API requests from these domains are processed without CORS errors

### Why make this change?

This change ensures the API is accessible from all variations of the SmartSwipe domain, including both the www and non-www versions, as well as both HTTP and HTTPS protocols. This prevents CORS errors when users access the application through different URL variations.