### PR TITLE
FE: hardcode BE endpoint

### DIFF
--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = process.env.REACT_APP_API_URL || 'http://127.0.0.1:5001/api';
+const API_URL = "https://swipe-owzj.onrender.com/api";
 
 const api = axios.create({
   baseURL: API_URL,


### PR DESCRIPTION
### TL;DR

Updated API endpoint URL to point to the production server.

### What changed?

Changed the API_URL constant from using an environment variable with localhost fallback to directly using the production URL `https://swipe-owzj.onrender.com/api`.

### How to test?

1. Run the client application
2. Verify API requests are being sent to the production server
3. Confirm that API functionality works as expected with the new endpoint

### Why make this change?

This change hardcodes the API endpoint to the production server hosted on Render, eliminating the need for environment variable configuration and ensuring consistent API connectivity across all environments. This simplifies deployment and prevents accidental connections to development servers.